### PR TITLE
Bugfix/null callbacks

### DIFF
--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -66,7 +66,7 @@ namespace Enklu.Orchid.Jint
 
             for (int i = 0; i < argsLength; ++i)
             {
-                jsArgs[i] = JsValue.FromObject(_context.Engine, argsLength);
+                jsArgs[i] = JsValue.FromObject(_context.Engine, args[i]);
             }
 
             var result = _callback(jsThis, jsArgs);

--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -44,9 +44,10 @@ namespace Enklu.Orchid.Jint
                 ? JsValue.FromObject(_context.Engine, @this)
                 : _binding;
 
-            var jsArgs = new JsValue[args.Length];
+            var argsLength = args?.Length ?? 0;
+            var jsArgs = new JsValue[argsLength];
 
-            for (int i = 0; i < args.Length; ++i)
+            for (int i = 0; i < argsLength; ++i)
             {
                 jsArgs[i] = JsValue.FromObject(_context.Engine, args[i]);
             }
@@ -59,11 +60,13 @@ namespace Enklu.Orchid.Jint
         public object Invoke(params object[] args)
         {
             var jsThis = _binding == null ? JsValue.Null : _binding;
-            var jsArgs = new JsValue[args.Length];
+            
+            var argsLength = args?.Length ?? 0;
+            var jsArgs = new JsValue[argsLength];
 
-            for (int i = 0; i < args.Length; ++i)
+            for (int i = 0; i < argsLength; ++i)
             {
-                jsArgs[i] = JsValue.FromObject(_context.Engine, args[i]);
+                jsArgs[i] = JsValue.FromObject(_context.Engine, argsLength);
             }
 
             var result = _callback(jsThis, jsArgs);

--- a/Orchid.Jint/Orchid.Jint.csproj
+++ b/Orchid.Jint/Orchid.Jint.csproj
@@ -5,9 +5,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>
-    <PackageVersion>1.0.1</PackageVersion>
-    <AssemblyVersion>1.0.1</AssemblyVersion>
-    <FileVersion>1.0.1</FileVersion>
+    <PackageVersion>1.0.2</PackageVersion>
+    <AssemblyVersion>1.0.2</AssemblyVersion>
+    <FileVersion>1.0.2</FileVersion>
       <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> -->
   </PropertyGroup>
 

--- a/Orchid.Jint/Orchid.Jint.csproj
+++ b/Orchid.Jint/Orchid.Jint.csproj
@@ -5,6 +5,9 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>
+    <PackageVersion>1.0.1</PackageVersion>
+    <AssemblyVersion>1.0.1</AssemblyVersion>
+    <FileVersion>1.0.1</FileVersion>
       <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> -->
   </PropertyGroup>
 


### PR DESCRIPTION
`null` is valid in `params object[] args`, which enkluplayer is using when trying to invoke `IJsCallback`s that don't have associated payloads.