### PR TITLE
Feature/error logging

### DIFF
--- a/Orchid.Chakra.Tests/OrchidChakraTests.cs
+++ b/Orchid.Chakra.Tests/OrchidChakraTests.cs
@@ -242,7 +242,7 @@ namespace Enklu.Orchid.Chakra.Tests
         private JsExecutionContext NewTestExecutionContext(JsRuntime runtime)
         {
             var context = (JsExecutionContext) runtime.NewExecutionContext();
-            context.RunScript("function assert(a) { if (!a) throw new Error('Failed Assertion'); };");
+            context.RunScript(string.Empty, "function assert(a) { if (!a) throw new Error('Failed Assertion'); };");
 
             var binding = context.NewJsObject();
             binding.AddFunction("log",
@@ -300,7 +300,7 @@ namespace Enklu.Orchid.Chakra.Tests
         {
             RunTest(context =>
             {
-                context.RunScript("console.log('Hello World!');");
+                context.RunScript(string.Empty, "console.log('Hello World!');");
             });
 
             Assert.AreEqual(1, _totalLogCalls);
@@ -312,7 +312,7 @@ namespace Enklu.Orchid.Chakra.Tests
             RunTest(context =>
             {
                 context.SetValue("simple", _simpleObject);
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     simple.SingleByteParameter(6);
                     simple.SingleShortParameter(55);
                     simple.SingleIntParameter(1024);
@@ -343,7 +343,7 @@ namespace Enklu.Orchid.Chakra.Tests
                 try
                 {
                     context.SetValue("simple", _simpleObject);
-                    context.RunScript(@"
+                    context.RunScript(string.Empty, @"
                         simple.SingleByteParameter(simple.A);
                         simple.SingleShortParameter(simple.B);
                         simple.SingleIntParameter(simple.C);
@@ -379,7 +379,7 @@ namespace Enklu.Orchid.Chakra.Tests
             {
                 var foo = new Foo();
                 context.SetValue("foo", foo);
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     foo.test(function(a, b, c) {
                         console.log('a: ' + a + ', b: ' + b + ', c: ' + c);
 
@@ -412,7 +412,7 @@ namespace Enklu.Orchid.Chakra.Tests
                 jsObj.SetValue("run", a);
                 context.SetValue("test", jsObj);
 
-                context.RunScript("test.run(5, 'testing 1 2 3');");
+                context.RunScript(string.Empty, "test.run(5, 'testing 1 2 3');");
             });
 
             Assert.AreEqual(1, callCount);
@@ -435,7 +435,7 @@ namespace Enklu.Orchid.Chakra.Tests
                 jsObj.SetValue("run", a);
                 context.SetValue("test", jsObj);
 
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     var result = test.run(5, 'testing 1 2 3');
                     console.log(result);
 
@@ -462,7 +462,7 @@ namespace Enklu.Orchid.Chakra.Tests
                     });
 
                 context.SetValue("bar", new Bar(52) {Widget = new Widget() {StrProp = "WidgetProp", IntProp = 5}});
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     passBar(33, bar);
                     var w = bar.Widget;
                     console.log(w.StrProp);");
@@ -475,7 +475,7 @@ namespace Enklu.Orchid.Chakra.Tests
             RunTest(context =>
             {
                 context.SetValue("container", new Container());
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     var all = container.all();
                     for (var i = 0; i < all.Count; ++i) {
                         console.log(all.get_Item(i));
@@ -507,7 +507,7 @@ namespace Enklu.Orchid.Chakra.Tests
                 var tester = new DelegateRefTester();
                 context.SetValue("tester", tester);
 
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     function doStuff(i, s) {
                         console.log('i: ' + i  + ', s: ' + s);
                     }
@@ -532,7 +532,7 @@ namespace Enklu.Orchid.Chakra.Tests
                 };
                 context.SetValue("callback", callback);
 
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     callback();
                 ");
 
@@ -553,7 +553,7 @@ namespace Enklu.Orchid.Chakra.Tests
 
                 context.SetValue("DoSomething", DoSomething);
 
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     function onDoSomething(a, b, c) {
                         console.log('a: ' + a + ', b: ' + b + ', c: ' + c);
                         return [ 'a', 'b', 'c' ];
@@ -569,7 +569,7 @@ namespace Enklu.Orchid.Chakra.Tests
         {
             RunTest(context =>
             {
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     function foo(a, b, c) {
                         console.log('a: ' + a + ', b: ' + b + ', c: ' + c);
                     }");
@@ -628,7 +628,7 @@ namespace Enklu.Orchid.Chakra.Tests
 
                 context.SetValue("require", new Func<string, object>(value => Resolve(value)));
 
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     var drawing = require('drawing') || { register: function() {} };
 
                     drawing.register('test', draw);
@@ -654,7 +654,7 @@ namespace Enklu.Orchid.Chakra.Tests
         {
             RunTest(context =>
             {
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     class Shape {
                         constructor (id, x, y) {
                             this.id = id
@@ -695,7 +695,7 @@ namespace Enklu.Orchid.Chakra.Tests
             {
                 var a = new SubClass();
 
-                context.RunScript(a, @"
+                context.RunScript(string.Empty, a, @"
                     this.DoAThing(5);
                     this.DoSomething(10);
                 ");
@@ -747,7 +747,7 @@ namespace Enklu.Orchid.Chakra.Tests
             {
                 var outer = new Outer();
                 //context.SetValue("outer", outer);
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     function acceptOuter(o) {
                         o.Dive(function(inner) {
                             var innerInner = inner.Dive();
@@ -767,7 +767,7 @@ namespace Enklu.Orchid.Chakra.Tests
                 Exception e = null;
                 try
                 {
-                    context.RunScript("execute();");
+                    context.RunScript(string.Empty, "execute();");
                 }
                 catch (Exception ee)
                 {
@@ -829,7 +829,7 @@ namespace Enklu.Orchid.Chakra.Tests
                 var cc = new CallCount();
                 var module = context.NewModule("module_1234");
 
-                context.RunScript(cc, script, module);
+                context.RunScript(string.Empty, cc, script, module);
 
                 var fn = module.GetExportedValue<IJsCallback>("enter");
                 fn.Invoke();
@@ -912,7 +912,7 @@ namespace Enklu.Orchid.Chakra.Tests
             RunTest(context =>
             {
                 context.SetValue("ele", new ArrayContainer());
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     var elements = ele.Elements;
 
                     for (var i in elements) {
@@ -936,7 +936,7 @@ namespace Enklu.Orchid.Chakra.Tests
 
                 context.SetValue("makeCallback", receiveCallback);
                 context.SetValue("ele", new ArrayContainer());
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     var elements = ele.Elements;
 
                     for (var i in elements) {
@@ -1016,27 +1016,27 @@ namespace Enklu.Orchid.Chakra.Tests
                 var vaTest = new VarArgTest(onCall);
                 context.SetValue("vaTest", vaTest);
                 context.SetValue("t", new CallCount());
-                context.RunScript("vaTest.Accept('hello', 13);");
-                context.RunScript("vaTest.Accept('test', 13, 'a', 'b', 'c', 'd', 'e', 'f', 32.5, t);");
-                context.RunScript("vaTest.Accept('test', 'me again');");
+                context.RunScript(string.Empty, "vaTest.Accept('hello', 13);");
+                context.RunScript(string.Empty, "vaTest.Accept('test', 13, 'a', 'b', 'c', 'd', 'e', 'f', 32.5, t);");
+                context.RunScript(string.Empty, "vaTest.Accept('test', 'me again');");
                 context.SetValue("foo", new FooObj {Name = "Bill"});
-                context.RunScript("vaTest.Accept(foo, 1, 2, 3);");
-                context.RunScript("vaTest.Accept();");
+                context.RunScript(string.Empty, "vaTest.Accept(foo, 1, 2, 3);");
+                context.RunScript(string.Empty, "vaTest.Accept();");
                 Assert.Throws<Exception>(() =>
                 {
-                    context.RunScript("vaTest.Accept('test', 'me', 1, 2, 3);");
+                    context.RunScript(string.Empty, "vaTest.Accept('test', 'me', 1, 2, 3);");
                 });
                 context.SetValue("foo", new FooObj {Name = "Bill"});
-                context.RunScript("vaTest.Accept(foo, 1, 2, 3);");
+                context.RunScript(string.Empty, "vaTest.Accept(foo, 1, 2, 3);");
 
-                context.RunScript("vaTest.Accept(55, 'hi');");
-                context.RunScript("vaTest.Accept(true, 'hiyo', 15, 'what', 'up', 'brother?');");
-                context.RunScript("vaTest.Accept(23, 'hiyo', 15, 'what', 'up', 'brother?', foo);");
+                context.RunScript(string.Empty, "vaTest.Accept(55, 'hi');");
+                context.RunScript(string.Empty, "vaTest.Accept(true, 'hiyo', 15, 'what', 'up', 'brother?');");
+                context.RunScript(string.Empty, "vaTest.Accept(23, 'hiyo', 15, 'what', 'up', 'brother?', foo);");
                 Assert.Throws<Exception>(() =>
                 {
-                    context.RunScript("vaTest.Accept(false, 'hiyo', 15, 'what', 'up', 'brother?', foo);");
+                    context.RunScript(string.Empty, "vaTest.Accept(false, 'hiyo', 15, 'what', 'up', 'brother?', foo);");
                 });
-                context.RunScript("vaTest.Accept(5, [ 1, 2, 3, 4, 5 ], 'whee', 'whee', 'what');");
+                context.RunScript(string.Empty, "vaTest.Accept(5, [ 1, 2, 3, 4, 5 ], 'whee', 'whee', 'what');");
             });
 
             Asserter.AreEqual(callArray, new int[] {1, 2, 2, 3, 1, 1});
@@ -1056,7 +1056,7 @@ namespace Enklu.Orchid.Chakra.Tests
             RunTest(context =>
             {
                 context.SetValue("d", new OptParam());
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     d.dispatch('my-evt');
                 ");
             });
@@ -1084,7 +1084,7 @@ namespace Enklu.Orchid.Chakra.Tests
             RunTest(context =>
             {
                 context.SetValue("thing", new NullReturner());
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     var aThing = thing.GetProperty('foo');
                     assert(!aThing);
                 ");
@@ -1097,7 +1097,7 @@ namespace Enklu.Orchid.Chakra.Tests
             RunTest(context =>
             {
                 context.SetValue("foo", new FooObj {Name="TestFoo"});
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     function output(someObj) {
                         for (var k in someObj) {
                             console.log('key: ' + k + ' = ' + someObj[k]);
@@ -1119,7 +1119,7 @@ namespace Enklu.Orchid.Chakra.Tests
                     callback.Invoke(o);
                 }));
 
-                context.RunScript(@"
+                context.RunScript(string.Empty, @"
                     receiver({
                         prop1: 'test 1 2 3',
                         prop2: 24,
@@ -1187,9 +1187,9 @@ namespace Enklu.Orchid.Chakra.Tests
                 var b = new InvokeCacheObj();
                 var c = new InvokeCacheObj();
 
-                context.RunScript(a, script, modA);
-                context.RunScript(b, script, modB);
-                context.RunScript(c, script, modC);
+                context.RunScript(string.Empty, a, script, modA);
+                context.RunScript(string.Empty, b, script, modB);
+                context.RunScript(string.Empty, c, script, modC);
 
                 var callA = modA.GetExportedValue<IJsCallback>("callAll");
                 var callB = modB.GetExportedValue<IJsCallback>("callAll");
@@ -1227,7 +1227,7 @@ namespace Enklu.Orchid.Chakra.Tests
                 {
                     jsCallback.Apply(this);
                 });
-            context.RunScript(@"
+            context.RunScript(string.Empty, @"
 'use strict';
 
 class JsElementApi {
@@ -1265,7 +1265,7 @@ var another = new AnotherContext();
 var thisBinding = new JsElementApi();
 var module_1234 = { };
 
-// RunScript(Program)
+// RunScript(string.Empty, Program)
 (function(module) {
     const self = this;
 

--- a/Orchid.Chakra/Interop/JsCallback.cs
+++ b/Orchid.Chakra/Interop/JsCallback.cs
@@ -16,6 +16,9 @@ namespace Enklu.Orchid.Chakra.Interop
         /// <inheritDoc />
         public IJsExecutionContext ExecutionContext => _context;
 
+        /// <inheritDoc />
+        public Exception ExecutionError { get; }
+
         /// <summary>
         /// Creates a new <see cref="JsCallback"/> instance.
         /// </summary>

--- a/Orchid.Chakra/Interop/JsModule.cs
+++ b/Orchid.Chakra/Interop/JsModule.cs
@@ -10,6 +10,9 @@
 
         /// <inheritdoc/>
         public string ModuleId { get; }
+        
+        /// <inheritdoc/>
+        public string Name { get; }
 
         /// <summary>
         /// The module binding specifically for the Chakra implementation.
@@ -26,6 +29,7 @@
             _interop = interop;
 
             ModuleId = moduleId;
+            Name = moduleId;
 
             // Create JS Representation
             Module = _scope.Run(() =>

--- a/Orchid.Chakra/Interop/JsModule.cs
+++ b/Orchid.Chakra/Interop/JsModule.cs
@@ -29,7 +29,6 @@
             _interop = interop;
 
             ModuleId = moduleId;
-            Name = moduleId;
 
             // Create JS Representation
             Module = _scope.Run(() =>

--- a/Orchid.Chakra/JsExecutionContext.cs
+++ b/Orchid.Chakra/JsExecutionContext.cs
@@ -67,7 +67,7 @@ namespace Enklu.Orchid.Chakra
         /// </summary>
         /// <param name="moduleId"></param>
         /// <returns></returns>
-        public IJsModule NewModule(string moduleId, string name = null)
+        public IJsModule NewModule(string moduleId)
         {
             return new JsModule(_scope, _binder, _interop, moduleId);
         }

--- a/Orchid.Chakra/JsExecutionContext.cs
+++ b/Orchid.Chakra/JsExecutionContext.cs
@@ -99,7 +99,7 @@ namespace Enklu.Orchid.Chakra
         /// <summary>
         /// Executes JavaScript code in the context of the global object/scope.
         /// </summary>
-        public void RunScript(string script)
+        public void RunScript(string name, string script)
         {
             _scope.Run(() =>
             {
@@ -119,9 +119,11 @@ namespace Enklu.Orchid.Chakra
         /// <summary>
         /// Executes JavaScript in the context of the <c>@this</c> parameter.
         /// </summary>
-        /// <param name="@this">The context of execution.</param>
+        /// <param name="name"></param>
+        /// <param name="this"></param>
         /// <param name="script">The script to run</param>
-        public void RunScript(object @this, string script)
+        /// <param name="@this">The context of execution.</param>
+        public void RunScript(string name, object @this, string script)
         {
             _scope.Run(() =>
             {
@@ -145,10 +147,12 @@ namespace Enklu.Orchid.Chakra
         /// Executes JavaScript in the context of the <c>@this</c> parameter, and allow exporting
         /// to a specific <see cref="IJsModule"/>.
         /// </summary>
-        /// <param name="@this">The context of execution.</param>
+        /// <param name="name"></param>
+        /// <param name="this"></param>
         /// <param name="script">The script to run</param>
         /// <param name="module">The module to export any inner properties to.</param>
-        public void RunScript(object @this, string script, IJsModule module)
+        /// <param name="@this">The context of execution.</param>
+        public void RunScript(string name, object @this, string script, IJsModule module)
         {
             _scope.Run(() =>
             {

--- a/Orchid.Chakra/JsExecutionContext.cs
+++ b/Orchid.Chakra/JsExecutionContext.cs
@@ -67,7 +67,7 @@ namespace Enklu.Orchid.Chakra
         /// </summary>
         /// <param name="moduleId"></param>
         /// <returns></returns>
-        public IJsModule NewModule(string moduleId)
+        public IJsModule NewModule(string moduleId, string name = null)
         {
             return new JsModule(_scope, _binder, _interop, moduleId);
         }

--- a/Orchid.Jint.Tests/Orchid.Jint.Tests.csproj
+++ b/Orchid.Jint.Tests/Orchid.Jint.Tests.csproj
@@ -16,6 +16,7 @@
   <ItemGroup>
     <ProjectReference Include="../Orchid/Orchid.csproj" />
     <ProjectReference Include="../Orchid.Jint/Orchid.Jint.csproj" />
+    <ProjectReference Include="..\..\Jint\Jint\Jint-Enklu.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Orchid.Jint.Tests/OrchidJintTests.cs
+++ b/Orchid.Jint.Tests/OrchidJintTests.cs
@@ -731,7 +731,7 @@ namespace Enklu.Orchid.Jint.Tests
 
                 var cc = new CallCount();
                 var moduleName = "TestModule";
-                var module = context.NewModule("module_1234", moduleName);
+                var module = context.NewModule("module_1234");
 
                 context.RunScript(moduleName, cc, script, module);
 

--- a/Orchid.Jint.Tests/OrchidJintTests.cs
+++ b/Orchid.Jint.Tests/OrchidJintTests.cs
@@ -711,32 +711,40 @@ namespace Enklu.Orchid.Jint.Tests
                         console.log('msgMissing');
                     }
 
+                    function buildCallback() 
+                    {
+                        return function() {
+                            nothing.error
+                        };
+                    }
+
                     if (typeof module !== 'undefined')
                     {
                         module.exports = {
                             enter: enter,
                             update: update,
                             exit: exit,
-                            msgMissing: msgMissing
+                            msgMissing: msgMissing,
+                            buildCallback: buildCallback
                         };
                     }";
 
                 var cc = new CallCount();
-                var module = context.NewModule("module_1234");
+                var moduleName = "TestModule";
+                var module = context.NewModule("module_1234", moduleName);
 
                 context.RunScript("Test", cc, script, module);
 
                 var fnEnter = module.GetExportedValue<IJsCallback>("enter");
-                Assert.AreEqual(module, fnEnter.ExecutionModule);
                 
                 fnEnter.Invoke();
                 Assert.IsNull(fnEnter.ExecutionError);
 
                 var fnExit = module.GetExportedValue<IJsCallback>("exit");
-                Assert.AreEqual(module, fnExit.ExecutionModule);
                 
                 fnExit.Invoke();
                 Assert.NotNull(fnExit.ExecutionError);
+                Assert.AreEqual(moduleName, ((JavaScriptException) fnExit.ExecutionError).Location.Source);
             });
         }
 

--- a/Orchid.Jint.Tests/OrchidJintTests.cs
+++ b/Orchid.Jint.Tests/OrchidJintTests.cs
@@ -225,7 +225,7 @@ namespace Enklu.Orchid.Jint.Tests
         private JsExecutionContext NewTestExecutionContext(JsRuntime runtime)
         {
             var context = (JsExecutionContext) runtime.NewExecutionContext();
-            context.RunScript("function assert(a) { if (!a) throw new Error('Failed Assertion'); };");
+            context.RunScript("Test", "function assert(a) { if (!a) throw new Error('Failed Assertion'); };");
 
             context.SetValue("console", _consoleLog);
 
@@ -272,7 +272,7 @@ namespace Enklu.Orchid.Jint.Tests
         {
             RunTest(context =>
             {
-                context.RunScript("console.log('Hello World!');");
+                context.RunScript("Test", "console.log('Hello World!');");
             });
 
             Assert.AreEqual(1, _consoleLog.TotalLogCalls);
@@ -284,7 +284,7 @@ namespace Enklu.Orchid.Jint.Tests
             RunTest(context =>
             {
                 context.SetValue("simple", _simpleObject);
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     simple.SingleByteParameter(6);
                     simple.SingleShortParameter(55);
                     simple.SingleIntParameter(1024);
@@ -315,7 +315,7 @@ namespace Enklu.Orchid.Jint.Tests
                 try
                 {
                     context.SetValue("simple", _simpleObject);
-                    context.RunScript(@"
+                    context.RunScript("Test", @"
                         simple.SingleByteParameter(simple.A);
                         simple.SingleShortParameter(simple.B);
                         simple.SingleIntParameter(simple.C);
@@ -351,7 +351,7 @@ namespace Enklu.Orchid.Jint.Tests
             {
                 var foo = new Foo();
                 context.SetValue("foo", foo);
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     foo.test(function(a, b, c) {
                         console.log('a: ' + a + ', b: ' + b + ', c: ' + c);
 
@@ -380,7 +380,7 @@ namespace Enklu.Orchid.Jint.Tests
                     });
 
                 context.SetValue("bar", new Bar(52) { Widget = new Widget() { StrProp = "WidgetProp", IntProp = 5 } });
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     passBar(33, bar);
                     var w = bar.Widget;
                     console.log(w.StrProp);");
@@ -393,7 +393,7 @@ namespace Enklu.Orchid.Jint.Tests
             RunTest(context =>
             {
                 context.SetValue("container", new Container());
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     var all = container.all();
                     for (var i = 0; i < all.Count; ++i) {
                         console.log(all.get_Item(i));
@@ -425,7 +425,7 @@ namespace Enklu.Orchid.Jint.Tests
                 var tester = new DelegateRefTester();
                 context.SetValue("tester", tester);
 
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     function doStuff(i, s) {
                         console.log('i: ' + i  + ', s: ' + s);
                     }
@@ -450,7 +450,7 @@ namespace Enklu.Orchid.Jint.Tests
                 };
                 context.SetValue("callback", callback);
 
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     callback();
                 ");
 
@@ -471,7 +471,7 @@ namespace Enklu.Orchid.Jint.Tests
 
                 context.SetValue("DoSomething", DoSomething);
 
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     function onDoSomething(a, b, c) {
                         console.log('a: ' + a + ', b: ' + b + ', c: ' + c);
                         return [ 'a', 'b', 'c' ];
@@ -487,7 +487,7 @@ namespace Enklu.Orchid.Jint.Tests
         {
             RunTest(context =>
             {
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     function foo(a, b, c) {
                         console.log('a: ' + a + ', b: ' + b + ', c: ' + c);
                     }");
@@ -546,7 +546,7 @@ namespace Enklu.Orchid.Jint.Tests
 
                 context.SetValue("require", new Func<string, object>(value => Resolve(value)));
 
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     var drawing = require('drawing') || { register: function() {} };
 
                     drawing.register('test', draw);
@@ -590,7 +590,7 @@ namespace Enklu.Orchid.Jint.Tests
             {
                 var a = new SubClass();
 
-                context.RunScript(a, @"
+                context.RunScript("Test", a, @"
                     this.DoAThing(5);
                     this.DoSomething(10);
                 ");
@@ -642,7 +642,7 @@ namespace Enklu.Orchid.Jint.Tests
             {
                 var outer = new Outer();
                 //context.SetValue("outer", outer);
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     function acceptOuter(o) {
                         o.Dive(function(inner) {
                             var innerInner = inner.Dive();
@@ -662,7 +662,7 @@ namespace Enklu.Orchid.Jint.Tests
                 Exception e = null;
                 try
                 {
-                    context.RunScript("execute();");
+                    context.RunScript("Test", "execute();");
                 }
                 catch (Exception ee)
                 {
@@ -724,7 +724,7 @@ namespace Enklu.Orchid.Jint.Tests
                 var cc = new CallCount();
                 var module = context.NewModule("module_1234");
 
-                context.RunScript(cc, script, module);
+                context.RunScript("Test", cc, script, module);
 
                 var fnEnter = module.GetExportedValue<IJsCallback>("enter");
                 Assert.AreEqual(module, fnEnter.ExecutionModule);
@@ -795,7 +795,7 @@ namespace Enklu.Orchid.Jint.Tests
             RunTest(context =>
             {
                 context.SetValue("ele", new ArrayContainer());
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     var elements = ele.Elements;
 
                     for (var i in elements) {
@@ -819,7 +819,7 @@ namespace Enklu.Orchid.Jint.Tests
 
                 context.SetValue("makeCallback", receiveCallback);
                 context.SetValue("ele", new ArrayContainer());
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     var elements = ele.Elements;
 
                     for (var i in elements) {
@@ -906,7 +906,7 @@ namespace Enklu.Orchid.Jint.Tests
             RunTest(context =>
             {
                 context.SetValue("thing", new NullReturner());
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     var aThing = thing.GetProperty('foo');
                     assert(!aThing);
                 ");
@@ -919,7 +919,7 @@ namespace Enklu.Orchid.Jint.Tests
             RunTest(context =>
             {
                 context.SetValue("foo", new FooObj { Name = "TestFoo" });
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     function output(someObj) {
                         for (var k in someObj) {
                             console.log('key: ' + k + ' = ' + someObj[k]);
@@ -941,7 +941,7 @@ namespace Enklu.Orchid.Jint.Tests
                     callback.Invoke(o);
                 }));
 
-                context.RunScript(@"
+                context.RunScript("Test", @"
                     receiver({
                         prop1: 'test 1 2 3',
                         prop2: 24,
@@ -1009,9 +1009,9 @@ namespace Enklu.Orchid.Jint.Tests
                 var b = new InvokeCacheObj();
                 var c = new InvokeCacheObj();
 
-                context.RunScript(a, script, modA);
-                context.RunScript(b, script, modB);
-                context.RunScript(c, script, modC);
+                context.RunScript("Test", a, script, modA);
+                context.RunScript("Test", b, script, modB);
+                context.RunScript("Test", c, script, modC);
 
                 var callA = modA.GetExportedValue<IJsCallback>("callAll");
                 var callB = modB.GetExportedValue<IJsCallback>("callAll");

--- a/Orchid.Jint.Tests/OrchidJintTests.cs
+++ b/Orchid.Jint.Tests/OrchidJintTests.cs
@@ -733,7 +733,7 @@ namespace Enklu.Orchid.Jint.Tests
                 var moduleName = "TestModule";
                 var module = context.NewModule("module_1234", moduleName);
 
-                context.RunScript("Test", cc, script, module);
+                context.RunScript(moduleName, cc, script, module);
 
                 var fnEnter = module.GetExportedValue<IJsCallback>("enter");
                 

--- a/Orchid.Jint.Tests/OrchidJintTests.cs
+++ b/Orchid.Jint.Tests/OrchidJintTests.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Enklu.Orchid.Jint;
+using Jint.Runtime;
 using NUnit.Framework;
 
 namespace Enklu.Orchid.Jint.Tests
@@ -702,7 +703,7 @@ namespace Enklu.Orchid.Jint.Tests
 
                     function exit()
                     {
-                        console.log('exit');
+                        nothing.error
                     }
 
                     function msgMissing()
@@ -725,8 +726,17 @@ namespace Enklu.Orchid.Jint.Tests
 
                 context.RunScript(cc, script, module);
 
-                var fn = module.GetExportedValue<IJsCallback>("enter");
-                fn.Invoke();
+                var fnEnter = module.GetExportedValue<IJsCallback>("enter");
+                Assert.AreEqual(module, fnEnter.ExecutionModule);
+                
+                fnEnter.Invoke();
+                Assert.IsNull(fnEnter.ExecutionError);
+
+                var fnExit = module.GetExportedValue<IJsCallback>("exit");
+                Assert.AreEqual(module, fnExit.ExecutionModule);
+                
+                fnExit.Invoke();
+                Assert.NotNull(fnExit.ExecutionError);
             });
         }
 

--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using Enklu.Orchid.Logging;
 using Jint;
 using Jint.Native;
+using Jint.Runtime;
 
 namespace Enklu.Orchid.Jint
 {
@@ -27,6 +29,12 @@ namespace Enklu.Orchid.Jint
 
         /// <inheritDoc />
         public IJsExecutionContext ExecutionContext => _context;
+        
+        /// <inheritDoc />
+        public IJsModule ExecutionModule { get; set; }
+
+        /// <inheritDoc />
+        public Exception ExecutionError { get; private set; }
 
         /// <summary>
         /// Creates a new <see cref="JsCallback"/> instance.
@@ -43,7 +51,7 @@ namespace Enklu.Orchid.Jint
             var jsThis = _binding == null
                 ? JsValue.FromObject(_context.Engine, @this)
                 : _binding;
-
+            
             var argsLength = args?.Length ?? 0;
             var jsArgs = new JsValue[argsLength];
 
@@ -52,8 +60,22 @@ namespace Enklu.Orchid.Jint
                 jsArgs[i] = JsValue.FromObject(_context.Engine, args[i]);
             }
 
-            var result = _callback(jsThis, jsArgs);
-            return result.ToObject();
+            try
+            {
+                var result = _callback(jsThis, jsArgs);
+                return result.ToObject();
+            }
+            catch (JavaScriptException jsError)
+            {
+                Log.Warning("Scripting", "[{0}:{1}] {2}", ExecutionModule?.Name, jsError.LineNumber, jsError.Message);
+                ExecutionError = jsError;
+            }
+            catch (Exception exception)
+            {
+                Log.Warning("Scripting", "[{0}] An unknown error has occured: {1}", ExecutionModule?.Name, exception);
+                ExecutionError = exception;
+            }
+            return null;
         }
 
         /// <inheritDoc />
@@ -69,8 +91,22 @@ namespace Enklu.Orchid.Jint
                 jsArgs[i] = JsValue.FromObject(_context.Engine, args[i]);
             }
 
-            var result = _callback(jsThis, jsArgs);
-            return result.ToObject();
+            try
+            {
+                var result = _callback(jsThis, jsArgs);
+                return result.ToObject();
+            }
+            catch (JavaScriptException jsError)
+            {
+                Log.Warning("Scripting", "[{0}:{1}] {2}", ExecutionModule?.Name, jsError.LineNumber, jsError.Message);
+                ExecutionError = jsError;
+            }
+            catch (Exception exception)
+            {
+                Log.Warning("Scripting", "[{0}] An unknown error has occured: {1}", ExecutionModule?.Name, exception);
+                ExecutionError = exception;
+            }
+            return null;
         }
 
         /// <inheritDoc />

--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -69,7 +69,8 @@ namespace Enklu.Orchid.Jint
             }
             catch (Exception exception)
             {
-                Log.Warning("Scripting", "An unknown error has occured: {1}", exception);
+                // TODO: Most recent js stack trace?
+                Log.Warning("Scripting", "An unknown error has occured: {0}", exception);
                 ExecutionError = exception;
             }
             return null;
@@ -100,7 +101,8 @@ namespace Enklu.Orchid.Jint
             }
             catch (Exception exception)
             {
-                Log.Warning("Scripting", "An unknown error has occured: {1}", exception);
+                // TODO: Most recent js stack trace?
+                Log.Warning("Scripting", "An unknown error has occured: {0}", exception);
                 ExecutionError = exception;
             }
             return null;

--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -29,9 +29,6 @@ namespace Enklu.Orchid.Jint
 
         /// <inheritDoc />
         public IJsExecutionContext ExecutionContext => _context;
-        
-        /// <inheritDoc />
-        public IJsModule ExecutionModule { get; set; }
 
         /// <inheritDoc />
         public Exception ExecutionError { get; private set; }
@@ -67,12 +64,12 @@ namespace Enklu.Orchid.Jint
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", ExecutionModule?.Name, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.Source, jsError.LineNumber, jsError.Message);
                 ExecutionError = jsError;
             }
             catch (Exception exception)
             {
-                Log.Warning("Scripting", "[{0}] An unknown error has occured: {1}", ExecutionModule?.Name, exception);
+                Log.Warning("Scripting", "An unknown error has occured: {1}", exception);
                 ExecutionError = exception;
             }
             return null;
@@ -98,12 +95,12 @@ namespace Enklu.Orchid.Jint
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", ExecutionModule?.Name, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.Source, jsError.LineNumber, jsError.Message);
                 ExecutionError = jsError;
             }
             catch (Exception exception)
             {
-                Log.Warning("Scripting", "[{0}] An unknown error has occured: {1}", ExecutionModule?.Name, exception);
+                Log.Warning("Scripting", "An unknown error has occured: {1}", exception);
                 ExecutionError = exception;
             }
             return null;

--- a/Orchid.Jint/JsExecutionContext.cs
+++ b/Orchid.Jint/JsExecutionContext.cs
@@ -37,9 +37,9 @@ namespace Enklu.Orchid.Jint
         }
 
         /// <inheritdoc />
-        public IJsModule NewModule(string moduleId, string name = null)
+        public IJsModule NewModule(string moduleId)
         {
-            return new JsModule(_engine, moduleId, name);
+            return new JsModule(_engine, moduleId);
         }
 
         /// <inheritdoc />

--- a/Orchid.Jint/JsExecutionContext.cs
+++ b/Orchid.Jint/JsExecutionContext.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Enklu.Orchid.Logging;
 using Jint;
 using Jint.Native;
+using Jint.Parser;
 using Jint.Runtime;
 
 namespace Enklu.Orchid.Jint
@@ -91,7 +92,10 @@ namespace Enklu.Orchid.Jint
         {
             try
             {
-                _engine.Execute(script);
+                _engine.Execute(script, new ParserOptions
+                {
+                    Source = name
+                });
             }
             catch (JavaScriptException jsError)
             {
@@ -105,7 +109,7 @@ namespace Enklu.Orchid.Jint
             var jsThis = JsValue.FromObject(_engine, @this);
             var jsScript = $"(function() {{ {script} }})";
 
-            var fn = _engine.Execute(jsScript).GetCompletionValue();
+            var fn = _engine.Execute(jsScript, new ParserOptions { Source = name }).GetCompletionValue();
             try
             {
                 _engine.Invoke(fn, jsThis, new object[] { });
@@ -122,7 +126,7 @@ namespace Enklu.Orchid.Jint
             var jsThis = JsValue.FromObject(_engine, @this);
             var jsScript = $"(function(module) {{ {script} }})";
 
-            var fn = _engine.Execute(jsScript).GetCompletionValue();
+            var fn = _engine.Execute(jsScript, new ParserOptions { Source = name }).GetCompletionValue();
             try
             {
                 _engine.Invoke(fn, jsThis, new object[] { ((JsModule) module).Module });

--- a/Orchid.Jint/JsExecutionContext.cs
+++ b/Orchid.Jint/JsExecutionContext.cs
@@ -34,9 +34,9 @@ namespace Enklu.Orchid.Jint
         }
 
         /// <inheritdoc />
-        public IJsModule NewModule(string moduleId)
+        public IJsModule NewModule(string moduleId, string name = null)
         {
-            return new JsModule(_engine, moduleId);
+            return new JsModule(_engine, moduleId, name);
         }
 
         /// <inheritdoc />
@@ -94,7 +94,7 @@ namespace Enklu.Orchid.Jint
         public void RunScript(object @this, string script)
         {
             var jsThis = JsValue.FromObject(_engine, @this);
-            var jsScript = string.Format("(function() {{ {0} }})", script);
+            var jsScript = $"(function() {{ {script} }})";
 
             var fn = _engine.Execute(jsScript).GetCompletionValue();
             _engine.Invoke(fn, jsThis, new object[] { });
@@ -104,7 +104,7 @@ namespace Enklu.Orchid.Jint
         public void RunScript(object @this, string script, IJsModule module)
         {
             var jsThis = JsValue.FromObject(_engine, @this);
-            var jsScript = string.Format("(function(module) {{ {0} }})", script);
+            var jsScript = $"(function(module) {{ {script} }})";
 
             var fn = _engine.Execute(jsScript).GetCompletionValue();
             _engine.Invoke(fn, jsThis, new object[] { ((JsModule) module).Module });

--- a/Orchid.Jint/JsExecutionContext.cs
+++ b/Orchid.Jint/JsExecutionContext.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Reflection;
+using Enklu.Orchid.Logging;
 using Jint;
 using Jint.Native;
+using Jint.Runtime;
 
 namespace Enklu.Orchid.Jint
 {
@@ -85,29 +87,50 @@ namespace Enklu.Orchid.Jint
         }
 
         /// <inheritdoc />
-        public void RunScript(string script)
+        public void RunScript(string name, string script)
         {
-            _engine.Execute(script);
+            try
+            {
+                _engine.Execute(script);
+            }
+            catch (JavaScriptException jsError)
+            {
+                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.LineNumber, jsError.Message);
+            }
         }
 
         /// <inheritdoc />
-        public void RunScript(object @this, string script)
+        public void RunScript(string name, object @this, string script)
         {
             var jsThis = JsValue.FromObject(_engine, @this);
             var jsScript = $"(function() {{ {script} }})";
 
             var fn = _engine.Execute(jsScript).GetCompletionValue();
-            _engine.Invoke(fn, jsThis, new object[] { });
+            try
+            {
+                _engine.Invoke(fn, jsThis, new object[] { });
+            }
+            catch (JavaScriptException jsError)
+            {
+                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.LineNumber, jsError.Message);
+            }
         }
 
         /// <inheritdoc />
-        public void RunScript(object @this, string script, IJsModule module)
+        public void RunScript(string name, object @this, string script, IJsModule module)
         {
             var jsThis = JsValue.FromObject(_engine, @this);
             var jsScript = $"(function(module) {{ {script} }})";
 
             var fn = _engine.Execute(jsScript).GetCompletionValue();
-            _engine.Invoke(fn, jsThis, new object[] { ((JsModule) module).Module });
+            try
+            {
+                _engine.Invoke(fn, jsThis, new object[] { ((JsModule) module).Module });
+            }
+            catch (JavaScriptException jsError)
+            {
+                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.LineNumber, jsError.Message);
+            }
         }
 
         /// <inheritdoc />

--- a/Orchid.Jint/JsModule.cs
+++ b/Orchid.Jint/JsModule.cs
@@ -39,14 +39,7 @@ namespace Enklu.Orchid.Jint
                 _exports = moduleObj.Get("exports").AsObject();
             }
 
-            var export = _exports.Get(name).To<T>(_engine.ClrTypeConverter);
-
-            if (export is IJsCallback callback)
-            {
-                callback.ExecutionModule = this;
-            }
-            
-            return export;
+            return _exports.Get(name).To<T>(_engine.ClrTypeConverter);
         }
     }
 }

--- a/Orchid.Jint/JsModule.cs
+++ b/Orchid.Jint/JsModule.cs
@@ -17,11 +17,10 @@ namespace Enklu.Orchid.Jint
 
         public JsValue Module { get; }
 
-        public JsModule(Engine engine, string moduleId, string name = null)
+        public JsModule(Engine engine, string moduleId)
         {
             _engine = engine;
             ModuleId = moduleId;
-            Name = name ?? moduleId;
 
             Module = _engine.Object.Construct(Arguments.Empty);
         }

--- a/Orchid.Jint/Orchid.Jint.csproj
+++ b/Orchid.Jint/Orchid.Jint.csproj
@@ -6,8 +6,8 @@
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>
     <PackageVersion>1.0.2</PackageVersion>
-    <AssemblyVersion>1.0.2</AssemblyVersion>
-    <FileVersion>1.0.2</FileVersion>
+    <AssemblyVersion>2020.11.0</AssemblyVersion>
+    <FileVersion>2020.11.0</FileVersion>
       <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> -->
   </PropertyGroup>
 

--- a/Orchid.Jint/Orchid.Jint.csproj
+++ b/Orchid.Jint/Orchid.Jint.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>

--- a/Orchid/IJsCallback.cs
+++ b/Orchid/IJsCallback.cs
@@ -14,11 +14,6 @@ namespace Enklu.Orchid
         IJsExecutionContext ExecutionContext { get; }
         
         /// <summary>
-        /// The <see cref="IJsModule"/> the callback was created in.
-        /// </summary>
-        IJsModule ExecutionModule { get; set; }
-        
-        /// <summary>
         /// The most recent error, if any, from calling Apply or Invoke.
         /// </summary>
         Exception ExecutionError { get; }

--- a/Orchid/IJsCallback.cs
+++ b/Orchid/IJsCallback.cs
@@ -1,4 +1,6 @@
-﻿namespace Enklu.Orchid
+﻿using System;
+
+namespace Enklu.Orchid
 {
     /// <summary>
     /// This interface defines an implementation prototype for a callback function inside of the javascript
@@ -10,6 +12,16 @@
         /// This property contains the <see cref="IJsExecutionContext"/> the callback was created in.
         /// </summary>
         IJsExecutionContext ExecutionContext { get; }
+        
+        /// <summary>
+        /// The <see cref="IJsModule"/> the callback was created in.
+        /// </summary>
+        IJsModule ExecutionModule { get; set; }
+        
+        /// <summary>
+        /// The most recent error, if any, from calling Apply or Invoke.
+        /// </summary>
+        Exception ExecutionError { get; }
 
         /// <summary>
         /// This method invokes the javascript callback with the provided arguments. Invocation works identically

--- a/Orchid/IJsExecutionContext.cs
+++ b/Orchid/IJsExecutionContext.cs
@@ -18,9 +18,10 @@ namespace Enklu.Orchid
         /// <summary>
         /// Creates a new <see cref="IJsModule"/> implementation which can be passed to <see cref="RunScript(string)"/>
         /// </summary>
-        /// <param name="moduleId"></param>
+        /// <param name="moduleId">The module's id</param>
+        /// <param name="name">The module's friendly name.</param>
         /// <returns></returns>
-        IJsModule NewModule(string moduleId);
+        IJsModule NewModule(string moduleId, string name = null);
 
         /// <summary>
         /// Gets a property from the global object/scope.

--- a/Orchid/IJsExecutionContext.cs
+++ b/Orchid/IJsExecutionContext.cs
@@ -36,22 +36,24 @@ namespace Enklu.Orchid
         /// <summary>
         /// Executes JavaScript code in the context of the global object/scope.
         /// </summary>
-        void RunScript(string script);
+        void RunScript(string name, string script);
 
         /// <summary>
         /// Executes JavaScript in the context of the <c>@this</c> parameter.
         /// </summary>
-        /// <param name="@this">The context of execution.</param>
+        /// <param name="name">The name of the context.</param>
+        /// <param name="this">The context of execution.</param>
         /// <param name="script">The script to run</param>
-        void RunScript(object @this, string script);
+        void RunScript(string name, object @this, string script);
 
         /// <summary>
         /// Executes JavaScript in the context of the <c>@this</c> parameter, and allow exporting
         /// to a specific <see cref="IJsModule"/>.
         /// </summary>
-        /// <param name="@this">The context of execution.</param>
+        /// /// <param name="name">The name of the context.</param>
+        /// <param name="this">The context of execution.</param>
         /// <param name="script">The script to run</param>
         /// <param name="module">The module to export any inner properties to.</param>
-        void RunScript(object @this, string script, IJsModule module);
+        void RunScript(string name, object @this, string script, IJsModule module);
     }
 }

--- a/Orchid/IJsExecutionContext.cs
+++ b/Orchid/IJsExecutionContext.cs
@@ -19,9 +19,8 @@ namespace Enklu.Orchid
         /// Creates a new <see cref="IJsModule"/> implementation which can be passed to <see cref="RunScript(string)"/>
         /// </summary>
         /// <param name="moduleId">The module's id</param>
-        /// <param name="name">The module's friendly name.</param>
         /// <returns></returns>
-        IJsModule NewModule(string moduleId, string name = null);
+        IJsModule NewModule(string moduleId);
 
         /// <summary>
         /// Gets a property from the global object/scope.

--- a/Orchid/IJsModule.cs
+++ b/Orchid/IJsModule.cs
@@ -9,6 +9,11 @@
         /// Unique module identifier to prevent overlap across a global namespace.
         /// </summary>
         string ModuleId { get; }
+        
+        /// <summary>
+        /// Non-unique name for the module. Commonly the script's name.
+        /// </summary>
+        string Name { get; }
 
         /// <summary>
         /// Gets an exported value from the module.

--- a/Orchid/IJsModule.cs
+++ b/Orchid/IJsModule.cs
@@ -9,11 +9,6 @@
         /// Unique module identifier to prevent overlap across a global namespace.
         /// </summary>
         string ModuleId { get; }
-        
-        /// <summary>
-        /// Non-unique name for the module. Commonly the script's name.
-        /// </summary>
-        string Name { get; }
 
         /// <summary>
         /// Gets an exported value from the module.

--- a/Orchid/Orchid.csproj
+++ b/Orchid/Orchid.csproj
@@ -5,6 +5,8 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>
+    <AssemblyVersion>2020.11.0</AssemblyVersion>
+    <FileVersion>2020.11.0</FileVersion>
   </PropertyGroup>
 
 </Project>

--- a/Orchid/Orchid.csproj
+++ b/Orchid/Orchid.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>


### PR DESCRIPTION
`JsCallback` instances now log their own warnings/errors when `Apply` or `Invoke` is called. This provides much more informative errors for end users, including script names + line numbers. Callbacks internally handle messaging, so every single jsinterface doesn't need try/catch logic and matching string formatting.

Also, at a fundamental level `JsCallback`s never fail now. In the event of an error, `null` is returned. All of our usage of `JsCallback`s wrapped invokes with a try/catch that was only there to surface a warning/error and keep on executing. However if needed, `ExecutionError` is populated and can be checked after an invoke call to ensure it was successful.

Modules now have an optional name that can be set. Names do not have to be unique and are just used currently for informative log messages.

Maybe a slight performance increase or garbage reduction from an old `FIXME` getting fixed.