### PR TITLE
Stop using our fork of Jint and use the official one

### DIFF
--- a/Orchid.Chakra.Tests/Orchid.Chakra.Tests.csproj
+++ b/Orchid.Chakra.Tests/Orchid.Chakra.Tests.csproj
@@ -9,15 +9,15 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-    <PackageReference Include="Microsoft.ChakraCore" Version="1.11.14">
+    <PackageReference Include="Microsoft.ChakraCore" Version="1.11.24">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Orchid\Orchid.csproj"/>
-    <ProjectReference Include="..\Orchid.Chakra\Orchid.Chakra.csproj"/>
+    <ProjectReference Include="..\Orchid\Orchid.csproj" />
+    <ProjectReference Include="..\Orchid.Chakra\Orchid.Chakra.csproj" />
   </ItemGroup>
 
   <!-- 

--- a/Orchid.Chakra.sln
+++ b/Orchid.Chakra.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.28307.329
+# Visual Studio Version 17
+VisualStudioVersion = 17.10.35004.147
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orchid.Chakra", "Orchid.Chakra\Orchid.Chakra.csproj", "{63DFB681-18C5-483D-8710-31E2CE38C636}"
 EndProject
@@ -13,7 +13,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orchid.Jint", "Orchid.Jint\
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Orchid.Jint.Tests", "Orchid.Jint.Tests\Orchid.Jint.Tests.csproj", "{04BE75C2-9F46-42CD-831A-CDEC54CD965B}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jint-Enklu", "..\Jint\Jint\Jint-Enklu.csproj", "{EF07422C-DA5B-4068-A070-B508954316BF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jint", "..\..\jint\Jint\Jint.csproj", "{1AAC7550-5494-42C5-8552-72773945E38C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,10 +41,10 @@ Global
 		{04BE75C2-9F46-42CD-831A-CDEC54CD965B}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{04BE75C2-9F46-42CD-831A-CDEC54CD965B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{04BE75C2-9F46-42CD-831A-CDEC54CD965B}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EF07422C-DA5B-4068-A070-B508954316BF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EF07422C-DA5B-4068-A070-B508954316BF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EF07422C-DA5B-4068-A070-B508954316BF}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EF07422C-DA5B-4068-A070-B508954316BF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1AAC7550-5494-42C5-8552-72773945E38C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1AAC7550-5494-42C5-8552-72773945E38C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1AAC7550-5494-42C5-8552-72773945E38C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1AAC7550-5494-42C5-8552-72773945E38C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Orchid.Chakra/Orchid.Chakra.csproj
+++ b/Orchid.Chakra/Orchid.Chakra.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.ChakraCore" Version="1.11.14">
+    <PackageReference Include="Microsoft.ChakraCore" Version="1.11.24">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/Orchid.Jint.Tests/Orchid.Jint.Tests.csproj
+++ b/Orchid.Jint.Tests/Orchid.Jint.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net451</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/Orchid.Jint.Tests/Orchid.Jint.Tests.csproj
+++ b/Orchid.Jint.Tests/Orchid.Jint.Tests.csproj
@@ -17,14 +17,4 @@
     <ProjectReference Include="../Orchid.Jint/Orchid.Jint.csproj" />
   </ItemGroup>
 
-
-  <ItemGroup>
-    <Reference Include="Acornima">
-      <HintPath>..\..\..\jint\artifacts\bin\Jint\release_net462\Acornima.dll</HintPath>
-    </Reference>
-    <Reference Include="Jint">
-      <HintPath>..\..\..\jint\artifacts\bin\Jint\release_net462\Jint.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-
 </Project>

--- a/Orchid.Jint.Tests/Orchid.Jint.Tests.csproj
+++ b/Orchid.Jint.Tests/Orchid.Jint.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -9,14 +9,22 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
-    <PackageReference Include="Jint-Enklu" Version="2.9.1" />
   </ItemGroup>
 
 
   <ItemGroup>
     <ProjectReference Include="../Orchid/Orchid.csproj" />
     <ProjectReference Include="../Orchid.Jint/Orchid.Jint.csproj" />
-    <ProjectReference Include="..\..\Jint\Jint\Jint-Enklu.csproj" />
+  </ItemGroup>
+
+
+  <ItemGroup>
+    <Reference Include="Acornima">
+      <HintPath>..\..\..\jint\artifacts\bin\Jint\release_net462\Acornima.dll</HintPath>
+    </Reference>
+    <Reference Include="Jint">
+      <HintPath>..\..\..\jint\artifacts\bin\Jint\release_net462\Jint.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Orchid.Jint.Tests/OrchidJintTests.cs
+++ b/Orchid.Jint.Tests/OrchidJintTests.cs
@@ -940,7 +940,7 @@ namespace Enklu.Orchid.Jint.Tests
                 {
                     Console.WriteLine("Receiver");
 
-                    var d = (Dictionary<string, object>)o;
+                    var d = (IDictionary<string, object>)o;
                     foreach (var key in d.Keys)
                     {
                         Console.WriteLine($"Key: {key}, Value: {d[key]}");

--- a/Orchid.Jint/ICallableConversion.cs
+++ b/Orchid.Jint/ICallableConversion.cs
@@ -1,9 +1,5 @@
 ﻿using Jint.Native;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Enklu.Orchid.Jint
 {

--- a/Orchid.Jint/ICallableConversion.cs
+++ b/Orchid.Jint/ICallableConversion.cs
@@ -1,0 +1,21 @@
+﻿using Jint.Native;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Enklu.Orchid.Jint
+{
+  /// <summary>
+  /// This interface defines an implementation prototype of an object capable of converting a
+  /// <see cref="ICallable"/> into an alternative type required by the host.
+  /// </summary>
+  public interface ICallableConversion
+  {
+    /// <summary>
+    /// Converts a Jint <see cref="ICallable"/> into a object usually defined by type key.
+    /// </summary>
+    object Convert(Func<JsValue, JsValue[], JsValue> callable);
+  }
+}

--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -34,6 +34,33 @@ namespace Enklu.Orchid.Jint
         public Exception ExecutionError { get; private set; }
 
         /// <summary>
+        /// Extra information to help identify the context when reporting on errors
+        /// </summary>
+        private string _errorContext
+        {
+            get
+            {
+                if (_context == null)
+                {
+                    return "execution context missing or destroyed:";
+                }
+                try 
+                {
+                    var savedErrorContext = _context.GetValue<string>("errorContext");
+                    if(savedErrorContext == null || savedErrorContext.Length == 0)
+                    {
+                        return "";
+                    }
+                    return savedErrorContext + ":";
+                }
+                catch(Exception)
+                {
+                    return ""; // No additional context provided
+                }
+            }
+        }
+
+        /// <summary>
         /// Creates a new <see cref="JsCallback"/> instance.
         /// </summary>
         public JsCallback(JsExecutionContext context, Func<JsValue, JsValue[], JsValue> callback)
@@ -64,13 +91,13 @@ namespace Enklu.Orchid.Jint
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.Source, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", $"[{_errorContext}{jsError.Location.Source}:{jsError.LineNumber}] {jsError.Message}");
                 ExecutionError = jsError;
             }
             catch (Exception exception)
             {
                 // TODO: Most recent js stack trace?
-                Log.Warning("Scripting", "An unknown error has occured: {0}", exception);
+                Log.Warning("Scripting", $"An unknown error has occured: {_errorContext}{exception}");
                 ExecutionError = exception;
             }
             return null;
@@ -96,13 +123,13 @@ namespace Enklu.Orchid.Jint
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.Source, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", $"[{_errorContext}{jsError.Location.Source}:{jsError.LineNumber}] {jsError.Message}");
                 ExecutionError = jsError;
             }
             catch (Exception exception)
             {
                 // TODO: Most recent js stack trace?
-                Log.Warning("Scripting", "An unknown error has occured: {0}", exception);
+                Log.Warning("Scripting", $"An unknown error has occured: {_errorContext}{exception}");
                 ExecutionError = exception;
             }
             return null;

--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -47,13 +47,13 @@ namespace Enklu.Orchid.Jint
                 try 
                 {
                     var savedErrorContext = _context.GetValue<string>("errorContext");
-                    if(savedErrorContext == null || savedErrorContext.Length == 0)
+                    if (savedErrorContext == null || savedErrorContext.Length == 0)
                     {
                         return "";
                     }
                     return savedErrorContext + ":";
                 }
-                catch(Exception)
+                catch (Exception)
                 {
                     return ""; // No additional context provided
                 }

--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -64,7 +64,7 @@ namespace Enklu.Orchid.Jint
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.Source, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.SourceFile, jsError.Location.Start.Line, jsError.Message);
                 ExecutionError = jsError;
             }
             catch (Exception exception)
@@ -96,7 +96,7 @@ namespace Enklu.Orchid.Jint
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.Source, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.SourceFile, jsError.Location.Start.Line, jsError.Message);
                 ExecutionError = jsError;
             }
             catch (Exception exception)

--- a/Orchid.Jint/JsCallback.cs
+++ b/Orchid.Jint/JsCallback.cs
@@ -64,7 +64,7 @@ namespace Enklu.Orchid.Jint
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.SourceFile, jsError.Location.Start.Line, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.Source, jsError.LineNumber, jsError.Message);
                 ExecutionError = jsError;
             }
             catch (Exception exception)
@@ -96,7 +96,7 @@ namespace Enklu.Orchid.Jint
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.SourceFile, jsError.Location.Start.Line, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", jsError.Location.Source, jsError.LineNumber, jsError.Message);
                 ExecutionError = jsError;
             }
             catch (Exception exception)

--- a/Orchid.Jint/JsExecutionContext.cs
+++ b/Orchid.Jint/JsExecutionContext.cs
@@ -91,14 +91,11 @@ namespace Enklu.Orchid.Jint
         {
             try
             {
-                _engine.Execute(script, new ScriptParsingOptions  
-                {
-                    Source = name
-                });
+                _engine.Execute(script, name);
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.Location.Start.Line, jsError.Message);
             }
         }
 
@@ -108,14 +105,14 @@ namespace Enklu.Orchid.Jint
             var jsThis = JsValue.FromObject(_engine, @this);
             var jsScript = $"(function() {{ {script} }})";
 
-            var fn = _engine.Execute(jsScript, new ParserOptions { Source = name }).GetCompletionValue();
+            var fn = _engine.Evaluate(jsScript, name);
             try
             {
                 _engine.Invoke(fn, jsThis, new object[] { });
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.Location.Start.Line, jsError.Message);
             }
         }
 
@@ -125,14 +122,14 @@ namespace Enklu.Orchid.Jint
             var jsThis = JsValue.FromObject(_engine, @this);
             var jsScript = $"(function(module) {{ {script} }})";
 
-            var fn = _engine.Execute(jsScript, new ParserOptions { Source = name }).GetCompletionValue();
+            var fn = _engine.Evaluate(jsScript, name);
             try
             {
                 _engine.Invoke(fn, jsThis, new object[] { ((JsModule) module).Module });
             }
             catch (JavaScriptException jsError)
             {
-                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.LineNumber, jsError.Message);
+                Log.Warning("Scripting", "[{0}:{1}] {2}", name, jsError.Location.Start.Line, jsError.Message);
             }
         }
 
@@ -146,7 +143,7 @@ namespace Enklu.Orchid.Jint
 
             if (null != _engine)
             {
-                _engine.Destroy();
+                _engine.Dispose();
             }
 
             _engine = null;

--- a/Orchid.Jint/JsExecutionContext.cs
+++ b/Orchid.Jint/JsExecutionContext.cs
@@ -47,7 +47,7 @@ namespace Enklu.Orchid.Jint
         public T GetValue<T>(string name)
         {
             var value = _engine.GetValue(name);
-            var obj = value.ToObject();  // mps TODO: This was taken from To<>. Fix to follow DRY
+            var obj = value.ToObject();
             return (T)_engine.ClrTypeConverter.Convert(obj, typeof(T), CultureInfo.InvariantCulture);
         }
 
@@ -147,9 +147,9 @@ namespace Enklu.Orchid.Jint
                 OnExecutionContextDisposing.Invoke(this);
             }
 
-            if (null != _engine)
+            if (null != _engine && _engine is IDisposable disposableEngine)
             {
- //               _engine.Dispose();
+                disposableEngine.Dispose();
             }
 
             _engine = null;

--- a/Orchid.Jint/JsExecutionContext.cs
+++ b/Orchid.Jint/JsExecutionContext.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 using Enklu.Orchid.Logging;
 using Jint;
 using Jint.Native;
-using Jint.Parser;
 using Jint.Runtime;
 
 namespace Enklu.Orchid.Jint
@@ -46,7 +45,7 @@ namespace Enklu.Orchid.Jint
         public T GetValue<T>(string name)
         {
             var value = _engine.GetValue(name);
-            return value.To<T>(_engine.ClrTypeConverter);
+            return value.To<T>(_engine.TypeConverter);
         }
 
         /// <inheritdoc />
@@ -92,7 +91,7 @@ namespace Enklu.Orchid.Jint
         {
             try
             {
-                _engine.Execute(script, new ParserOptions
+                _engine.Execute(script, new ScriptParsingOptions  
                 {
                     Source = name
                 });

--- a/Orchid.Jint/JsModule.cs
+++ b/Orchid.Jint/JsModule.cs
@@ -22,7 +22,7 @@ namespace Enklu.Orchid.Jint
             _engine = engine;
             ModuleId = moduleId;
 
-            Module = _engine.Object.Construct(Arguments.Empty);
+            Module = _engine.Intrinsics.Object.Construct(Arguments.Empty);
         }
 
         public T GetExportedValue<T>(string name)
@@ -38,7 +38,7 @@ namespace Enklu.Orchid.Jint
                 _exports = moduleObj.Get("exports").AsObject();
             }
 
-            return _exports.Get(name).To<T>(_engine.ClrTypeConverter);
+            return _exports.Get(name).To<T>(_engine.TypeConverter);
         }
     }
 }

--- a/Orchid.Jint/JsModule.cs
+++ b/Orchid.Jint/JsModule.cs
@@ -2,6 +2,7 @@
 using Jint.Native;
 using Jint.Native.Object;
 using Jint.Runtime;
+using System.Globalization;
 
 namespace Enklu.Orchid.Jint
 {
@@ -22,7 +23,7 @@ namespace Enklu.Orchid.Jint
             _engine = engine;
             ModuleId = moduleId;
 
-            Module = _engine.Intrinsics.Object.Construct(Arguments.Empty);
+            Module = _engine.Object.Construct(Arguments.Empty);
         }
 
         public T GetExportedValue<T>(string name)
@@ -38,7 +39,8 @@ namespace Enklu.Orchid.Jint
                 _exports = moduleObj.Get("exports").AsObject();
             }
 
-            return _exports.Get(name).To<T>(_engine.TypeConverter);
+            var obj = _exports.Get(name).ToObject();  // mps TODO: This was taken from To<>. Fix to follow DRY
+            return (T)_engine.ClrTypeConverter.Convert(obj, typeof(T), CultureInfo.InvariantCulture);
         }
     }
 }

--- a/Orchid.Jint/JsRuntime.cs
+++ b/Orchid.Jint/JsRuntime.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Jint;
+using Jint.Runtime.Debugger;
 
 namespace Enklu.Orchid.Jint
 {
@@ -27,7 +28,7 @@ namespace Enklu.Orchid.Jint
 
                 // Debugging Configuration
                 options.DebugMode(false);
-                options.AllowDebuggerStatement(false);
+                options.DebuggerStatementHandling(DebuggerStatementHandling.Ignore);
             }) { }
 
         /// <summary>
@@ -40,7 +41,7 @@ namespace Enklu.Orchid.Jint
                 configure(options);
 
                 // Enhance existing option setting with Deny Attribute
-                options.DenyInteropAccessWith(typeof(DenyJsAccess));
+                // options.DenyInteropAccessWith(typeof(DenyJsAccess)); TODO: Create a new options type
             };
         }
 
@@ -50,7 +51,7 @@ namespace Enklu.Orchid.Jint
             var engine = new Engine(_configure);
             var executionContext = new JsExecutionContext(engine);
 
-            engine.ClrTypeConverter.RegisterDelegateConversion(
+            engine.TypeConverter.RegisterDelegateConversion(
                 typeof(IJsCallback),
                 new JsCallbackConversion(executionContext));
 

--- a/Orchid.Jint/JsRuntime.cs
+++ b/Orchid.Jint/JsRuntime.cs
@@ -28,7 +28,7 @@ namespace Enklu.Orchid.Jint
 
                 // Debugging Configuration
                 options.DebugMode(false);
-                options.DebuggerStatementHandling(DebuggerStatementHandling.Ignore);
+                options.AllowDebuggerStatement(false);
             }) { }
 
         /// <summary>
@@ -51,10 +51,7 @@ namespace Enklu.Orchid.Jint
             var engine = new Engine(_configure);
             var executionContext = new JsExecutionContext(engine);
 
-            engine.TypeConverter.RegisterDelegateConversion(
-                typeof(IJsCallback),
-                new JsCallbackConversion(executionContext));
-
+            engine.ClrTypeConverter = new OrchidTypeConverter(engine, executionContext);
             return executionContext;
         }
 

--- a/Orchid.Jint/Orchid.Jint.csproj
+++ b/Orchid.Jint/Orchid.Jint.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net451;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>
@@ -11,19 +11,24 @@
       <!--<CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies> -->
   </PropertyGroup>
 
-  <ItemGroup>
-    <!-- <PackageReference Include="Jint-Enklu" Version="2.9.1" />-->
-  </ItemGroup>
-
     <ItemGroup>
       <ProjectReference Include="../Orchid/Orchid.csproj" />
-      <ProjectReference Include="../../Jint/Jint/Jint-Enklu.csproj" />
+      <ProjectReference Include="..\..\..\jint\Jint\Jint.csproj" />
     </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="Acornima">
+      <HintPath>..\..\..\jint\artifacts\bin\Jint\release_net462\Acornima.dll</HintPath>
+    </Reference>
+    <Reference Include="Jint">
+      <HintPath>..\..\..\jint\artifacts\bin\Jint\release_net462\Jint.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Orchid.Jint/Orchid.Jint.csproj
+++ b/Orchid.Jint/Orchid.Jint.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net462</TargetFrameworks>
+    <TargetFrameworks>net451</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>Enklu</Company>
     <Authors>Enklu</Authors>
@@ -20,15 +20,6 @@
     <PackageReference Include="System.Diagnostics.Contracts" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="System.Reflection.TypeExtensions" Version="4.4.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="Acornima">
-      <HintPath>..\..\..\jint\artifacts\bin\Jint\release_net462\Acornima.dll</HintPath>
-    </Reference>
-    <Reference Include="Jint">
-      <HintPath>..\..\..\jint\artifacts\bin\Jint\release_net462\Jint.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Orchid.Jint/OrchidTypeConverter.cs
+++ b/Orchid.Jint/OrchidTypeConverter.cs
@@ -5,7 +5,7 @@ using Jint.Native;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-
+using System.Dynamic;
 
 namespace Enklu.Orchid.Jint
 {
@@ -59,6 +59,12 @@ namespace Enklu.Orchid.Jint
             var converted = _delegateConversions[type].Convert(function);
             return Cache(function, converted);
           }
+        }
+        // Some of the clients expect an actual Dictionary<string, object> where
+        // parsing JSON gives us an ExpandoObject, which implements IDictionary<string, object>
+        if (valueType.Equals(typeof(ExpandoObject)))
+        {
+          value = new Dictionary<string, object>(value as IDictionary<string, object>);
         }
       }
       return base.Convert(value, type, formatProvider);

--- a/Orchid.Jint/OrchidTypeConverter.cs
+++ b/Orchid.Jint/OrchidTypeConverter.cs
@@ -1,0 +1,44 @@
+﻿using Enklu.Orchid.Jint;
+using Jint;
+using Jint.Runtime.Interop;
+using Jint.Native;
+using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+
+namespace Orchid.Jint
+{
+  internal class OrchidTypeConverter: DefaultTypeConverter
+  {
+    public OrchidTypeConverter(Engine engine) : base(engine) { }
+
+    private readonly Dictionary<Delegate, object> _delegateCache = new Dictionary<Delegate, object>();
+    private readonly Dictionary<Type, ICallableConversion> _delegateConversions = new Dictionary<Type, ICallableConversion>();
+
+    private static Expression JsUndefExpr = Expression.Constant(JsValue.Undefined, typeof(JsValue));
+
+    /// <summary>
+    /// Registers a conversion operation for a specific target type. When the callable must be adapted to this type,
+    /// use the provided conversion operation.
+    /// </summary>
+    /// <param name="targetType">The <see cref="Type"/> of the object Jint is trying to convert the callable to.</param>
+    /// <param name="conversion">The conversion implementation to use for the specific target type</param>
+    public void RegisterDelegateConversion(Type targetType, ICallableConversion conversion)
+    {
+      if (_delegateConversions.ContainsKey(targetType))
+      {
+        return;
+      }
+
+      _delegateConversions[targetType] = conversion;
+    }
+    public override object? Convert(
+        object? value, Type type, IFormatProvider formatProvider)
+    {
+      return null;
+    }
+  }
+
+
+}


### PR DESCRIPTION
Gets off the old memory leaking fork of Jint that we had been using and uses the official one. We have been using this branch in production for a while, but still needs to be merged to develop